### PR TITLE
Add logged-in user to evaluation

### DIFF
--- a/evaluation_registry/evaluations/share_views.py
+++ b/evaluation_registry/evaluations/share_views.py
@@ -54,6 +54,8 @@ def evaluation_create_view(request, status):
         if form_complete:
             if form.is_valid():
                 new_evaluation = form.save()
+                new_evaluation.created_by = request.user
+                new_evaluation.save()
                 EvaluationDepartmentAssociation.objects.create(
                     evaluation=new_evaluation, department=form.cleaned_data["lead_department"], is_lead=True
                 )

--- a/evaluation_registry/evaluations/share_views.py
+++ b/evaluation_registry/evaluations/share_views.py
@@ -13,6 +13,7 @@ from evaluation_registry.evaluations.models import (
     EvaluationDepartmentAssociation,
 )
 from evaluation_registry.evaluations.views import (
+    check_evaluation_and_user,
     evaluation_dates_view,
     evaluation_description_view,
     evaluation_links_view,
@@ -146,10 +147,7 @@ def create_view(request, page_number=1, status=None):
 @require_http_methods(["GET", "POST"])
 @login_required
 def share_view(request, uuid, page_number):
-    try:
-        evaluation = Evaluation.objects.get(id=uuid)
-    except Evaluation.DoesNotExist:
-        raise Http404("No %(verbose_name)s found matching the query" % {"verbose_name": Evaluation._meta.verbose_name})
+    evaluation = check_evaluation_and_user(request, uuid)
 
     view_options = [
         {

--- a/tests/test_share_views.py
+++ b/tests/test_share_views.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 import pytest
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseForbidden
 
 from evaluation_registry.evaluations import share_views
 
@@ -46,3 +46,12 @@ def test_share_view_with_impact_type(alice, client, impact_evaluation):
     with patch.object(share_views, "evaluation_type_view", return_value=HttpResponse()) as mock_type_view:
         client.get(f"/evaluation/{impact_evaluation.id}/share/2/")
     mock_type_view.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_share_view_different_user(client, basic_evaluation, create_user):
+    baljit = create_user("baljit@example.com")
+    client.force_login(user=baljit)
+
+    response = client.get(f"/evaluation/{basic_evaluation.id}/share/1/")
+    assert isinstance(response, HttpResponseForbidden)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 import pytest
 from django.forms import Form
+from django.http import HttpResponseForbidden
 
 from evaluation_registry.evaluations.models import EvaluationDesignTypeDetail
 from evaluation_registry.evaluations.views import (
@@ -51,3 +52,12 @@ def test_evaluation_update_type_view(mock_render, client, basic_evaluation, impa
     _, _, data = mock_render.call_args[0]
     assert data["evaluation"] == basic_evaluation
     assert all([eval_type.parent == impact for eval_type in data["options"]])
+
+
+@pytest.mark.django_db
+def test_update_view_different_user(client, basic_evaluation, create_user):
+    baljit = create_user("baljit@example.com")
+    client.force_login(user=baljit)
+
+    response = client.get(f"/evaluation/{basic_evaluation.id}/update-type/")
+    assert isinstance(response, HttpResponseForbidden)


### PR DESCRIPTION
This adds a record of which user has created the evaluation to the Evaluation model
(as the view now requires logging in, there should *be* a user).
Also adds: 
- adding additional checks to the evaluation update views to ensure only the user who created the evaluation can change it
- testing the above

TODO in later PR
- show filtered evaluations for users when they click 'view my evaluations' from the homepage
- only showing Draft evaluations if they belong to a signed in user etc