### PR TITLE
Filter which evaluations are shown in the list view by user

### DIFF
--- a/evaluation_registry/evaluations/views.py
+++ b/evaluation_registry/evaluations/views.py
@@ -25,7 +25,7 @@ from evaluation_registry.evaluations.models import (
     EvaluationDesignType,
     EvaluationDesignTypeDetail,
     EventDate,
-    User
+    User,
 )
 
 
@@ -57,9 +57,8 @@ def homepage_view(request):
 def authorised_base_evaluation_queryset(show_public: bool, show_user: bool, user: User) -> QuerySet:
     if show_public:
         if show_user:
-            return (
-                Evaluation.objects.exclude(visibility=Evaluation.Visibility.DRAFT)
-                | Evaluation.objects.filter(created_by=user)
+            return Evaluation.objects.exclude(visibility=Evaluation.Visibility.DRAFT) | Evaluation.objects.filter(
+                created_by=user
             )
         return Evaluation.objects.exclude(visibility=Evaluation.Visibility.DRAFT)
     if show_user:
@@ -109,9 +108,7 @@ def evaluation_list_view(request):
 
     if request.user.is_authenticated:
         base_evaluation_queryset = authorised_base_evaluation_queryset(
-            show_public=('public' in evaluations_to_show),
-            show_user=('user' in evaluations_to_show),
-            user=request.user
+            show_public=("public" in evaluations_to_show), show_user=("user" in evaluations_to_show), user=request.user
         )
     else:
         base_evaluation_queryset = Evaluation.objects.filter(visibility=Evaluation.Visibility.PUBLIC)

--- a/evaluation_registry/templates/evaluation_list.html
+++ b/evaluation_registry/templates/evaluation_list.html
@@ -29,26 +29,26 @@
                     <div class="govuk-checkboxes__item">
                       <input
                         class="govuk-checkboxes__input"
-                        id="evaluations_to_show"
+                        id="evaluations_to_show-user"
                         name="evaluations_to_show"
                         type="checkbox"
                         value="user"
                         {% if 'user' in evaluations_to_show %}checked{% endif %}
                       >
-                      <label class="govuk-label govuk-checkboxes__label" for="evaluations_to_show">
+                      <label class="govuk-label govuk-checkboxes__label" for="evaluations_to_show-user">
                         Show my evaluations
                       </label>
                     </div>
                     <div class="govuk-checkboxes__item">
                       <input
                         class="govuk-checkboxes__input"
-                        id="evaluations_to_show"
+                        id="evaluations_to_show-public"
                         name="evaluations_to_show"
                         type="checkbox"
                         value="public"
                         {% if 'public' in evaluations_to_show %}checked{% endif %}
                       >
-                      <label class="govuk-label govuk-checkboxes__label" for="evaluations_to_show">
+                      <label class="govuk-label govuk-checkboxes__label" for="evaluations_to_show-public">
                         Show all available evaluations
                       </label>
                     </div>

--- a/evaluation_registry/templates/evaluation_list.html
+++ b/evaluation_registry/templates/evaluation_list.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-  <form method="GET" action="{{url('homepage')}}">
+  <form method="GET" action="{{url('search')}}">
     <div class="govuk-width-container">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
@@ -17,9 +17,49 @@
         <div class="govuk-grid-row">
 
           <div class="govuk-grid-column-one-third">
+            {% if is_authenticated %}
+              <div class="govuk-form-group">
+                <fieldset class="govuk-fieldset">
+                  <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                    <h2 class="govuk-fieldset__heading">
+                      Evaluations to show
+                    </h2>
+                  </legend>
+                  <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+                    <div class="govuk-checkboxes__item">
+                      <input
+                        class="govuk-checkboxes__input"
+                        id="evaluations_to_show"
+                        name="evaluations_to_show"
+                        type="checkbox"
+                        value="user"
+                        {% if 'user' in evaluations_to_show %}checked{% endif %}
+                      >
+                      <label class="govuk-label govuk-checkboxes__label" for="evaluations_to_show">
+                        Show my evaluations
+                      </label>
+                    </div>
+                    <div class="govuk-checkboxes__item">
+                      <input
+                        class="govuk-checkboxes__input"
+                        id="evaluations_to_show"
+                        name="evaluations_to_show"
+                        type="checkbox"
+                        value="public"
+                        {% if 'public' in evaluations_to_show %}checked{% endif %}
+                      >
+                      <label class="govuk-label govuk-checkboxes__label" for="evaluations_to_show">
+                        Show all available evaluations
+                      </label>
+                    </div>
+                  </div>
+                </fieldset>
+              </div>
+            {% endif %}
+
             <div class="govuk-form-group">
               <label class="govuk-label" for="search_term">
-                Search keywords
+                <h2 class="govuk-fieldset__legend govuk-fieldset__legend--m">Search keywords</h2>
               </label>
               <input class="govuk-input" id="search_term" name="search_term" type="text" value="{{search_term}}">
             </div>

--- a/evaluation_registry/templates/homepage.html
+++ b/evaluation_registry/templates/homepage.html
@@ -36,12 +36,12 @@
       <div class="govuk-grid-column-one-third">
         <h3 class="govuk-heading-m">I want to:</h3>
         <p>I've previously created a record for an evaluation and now want to update</p>
-          <a class="govuk-button govuk-button--start" href="{{ url('search') }}">Find my evaluation</a>
+          <a class="govuk-button govuk-button--start" href="{{ url('search') }}?evaluations_to_show=user">Find my evaluation</a>
       </div>
       <div class="govuk-grid-column-one-third">
         <h3 class="govuk-heading-m">I want to:</h3>
         <p>See all the evaluations in the Evaluation Registry</p>
-          <a class="govuk-button govuk-button--start" href="{{ url('search') }}">Search evaluations</a>
+          <a class="govuk-button govuk-button--start" href="{{ url('search') }}?evaluations_to_show=user&evaluations_to_show=public">Search evaluations</a>
       </div>
     </div>
     </main>

--- a/evaluation_registry/templates/share-form/confirmation.html
+++ b/evaluation_registry/templates/share-form/confirmation.html
@@ -17,7 +17,10 @@
         You can <a href="{{url('evaluation-detail', evaluation.id)}}" class="govuk-link">view</a> this entry.
       </p>
       <p class="govuk-body">
-        You can <a href="{{url('search')}}" class="govuk-link">view</a> all evaluations.
+        You can <a href="{{url('search')}}?evaluations_to_show=user" class="govuk-link">view</a> your evaluations.
+      </p>
+      <p class="govuk-body">
+        You can <a href="{{url('search')}}?evaluations_to_show=user&evaluations_to_show=public" class="govuk-link">view</a> all evaluations.
       </p>
       <p class="govuk-body">
         <a href="#" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -5,23 +5,21 @@ from evaluation_registry.evaluations.models import (
     EvaluationDepartmentAssociation,
 )
 from evaluation_registry.evaluations.views import (
+    authorised_base_evaluation_queryset,
     filter_by_department_and_types,
     full_text_search,
 )
 
 
 @pytest.fixture
-def evaluations(cabinet_office, home_office, impact, other):
-    e1 = Evaluation.objects.create(title="summaries of policies")
+def evaluations(alice, cabinet_office, home_office, impact, other):
+    e1 = Evaluation.objects.create(title="summaries of policies", created_by=alice)
     e2 = Evaluation.objects.create(
-        title="public transport",
-        brief_description="to long to detail here",
+        title="public transport", brief_description="to long to detail here", visibility=Evaluation.Visibility.PUBLIC
     )
     e2.evaluation_design_types.add(impact)
 
-    e3 = Evaluation.objects.create(
-        title="details of something or other",
-    )
+    e3 = Evaluation.objects.create(title="details of something or other", visibility=Evaluation.Visibility.DRAFT)
     e3.evaluation_design_types.add(impact)
     e3.evaluation_design_types.add(other)
 
@@ -42,6 +40,21 @@ def evaluations(cabinet_office, home_office, impact, other):
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
+    "show_public, show_user, expected_number_of_results",
+    [
+        (True, True, 2),
+        (True, False, 1),
+        (False, True, 1),
+        (False, False, 0),
+    ],
+)
+def test_authorised_base_evaluation_queryset(alice, evaluations, show_public, show_user, expected_number_of_results):
+    results = authorised_base_evaluation_queryset(show_public=show_public, show_user=show_user, user=alice)
+    assert len(results) == expected_number_of_results
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
     "search_term, expected_number_of_results, expected_lead_title",
     [
         ("policies", 1, "summaries of policies"),  # match one word
@@ -51,7 +64,7 @@ def evaluations(cabinet_office, home_office, impact, other):
     ],
 )
 def test_full_text_search(evaluations, search_term, expected_number_of_results, expected_lead_title):
-    results = full_text_search(search_term)
+    results = full_text_search(Evaluation.objects.all(), search_term)
     assert len(results) == expected_number_of_results
     assert results[0].title == expected_lead_title
 


### PR DESCRIPTION
Filters which evaluations are shown in the list view based on the user.

* Signed out users only see public evaluations
* Logged-in users can toggle their evaluations and the public/Civil Service ones on and off
* internal website links are updated 

_These checkboxes are only visible to authenticated users:_
<img width="1137" alt="Screenshot 2023-11-30 at 13 49 42" src="https://github.com/i-dot-ai/evaluation-registry/assets/23265724/5ed4bafa-a6d4-432d-bc1d-5708d3286a72">
