### PR TITLE
ignore bot errors in sentry

### DIFF
--- a/evaluation_registry/settings.py
+++ b/evaluation_registry/settings.py
@@ -48,6 +48,15 @@ AUTHENTICATION_BACKENDS = [
 ]
 
 
+def before_send(event, hint):
+    message_to_ignore = ("Invalid HTTP_HOST header",)  # Scrapers and bots
+
+    event_message = event.get("message")
+    if message_to_ignore in event_message:
+        return None
+    return event
+
+
 if not DEBUG:
     SENTRY_DSN = env.str("SENTRY_DSN", default="")
     SENTRY_ENVIRONMENT = env.str("SENTRY_ENVIRONMENT", default="")
@@ -61,6 +70,7 @@ if not DEBUG:
         send_default_pii=False,
         traces_sample_rate=1.0,
         profiles_sample_rate=0.0,
+        before_send=before_send,
     )
 
 


### PR DESCRIPTION
Ignore 'Disallowed Host' errors in Sentry, based on: https://github.com/i-dot-ai/one-big-thing/blob/fab5c00a5280dc118f56b9fa14275cc08c50e9c6/one_big_thing/settings.py#L198