### PR TITLE
Add select-related for taxonomy objects

### DIFF
--- a/evaluation_registry/evaluations/admin.py
+++ b/evaluation_registry/evaluations/admin.py
@@ -111,6 +111,10 @@ class TaxonomyAdmin(admin.ModelAdmin):
     list_display = ["code", "display", "parent"]
     list_filter = ["parent"]
 
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        return qs.select_related("parent")
+
 
 admin.site.register(models.Evaluation, EvaluationAdmin)
 admin.site.register(models.Department, DepartmentAdmin)

--- a/evaluation_registry/evaluations/views.py
+++ b/evaluation_registry/evaluations/views.py
@@ -435,7 +435,7 @@ def evaluation_update_links_view(request, uuid):
 def evaluation_policies_view(request, evaluation, next_page=None):
     EvaluationForm = modelform_factory(Evaluation, fields=["policies"])  # noqa: N806
     EvaluationForm.base_fields["policies"].to_field_name = "code"
-    policies = Taxonomy.objects.order_by("code")
+    policies = Taxonomy.objects.select_related("parent").order_by("code")
 
     selected_policies = list(map(lambda p: p.code, evaluation.policies.all()))
 


### PR DESCRIPTION
We have a few N+1 issues in Sentry around the Taxonomy object - this should help tackle these