### PR TITLE
Allow user to enter either an evaluation link or plan link

### DIFF
--- a/evaluation_registry/evaluations/forms.py
+++ b/evaluation_registry/evaluations/forms.py
@@ -102,10 +102,13 @@ class EvaluationShareForm(Form):
         if is_final_report_published:
             link_to_published_evaluation = self.cleaned_data.get("link_to_published_evaluation")
             plan_link = self.cleaned_data.get("plan_link")
-            if not plan_link:
-                self.add_error("plan_link", "Please provide a link to a strategy, plan or framework")
-            if not link_to_published_evaluation:
-                self.add_error("link_to_published_evaluation", "Please provide a link to a published evaluation")
+            if not (plan_link or link_to_published_evaluation):
+                self.add_error("plan_link", "Please provide at least one link to an evaluation document")
+                self.add_error(
+                    "link_to_published_evaluation",
+                    "Please provide at least one link to an evaluation document",
+                )
+
         else:
             reasons_unpublished = self.cleaned_data.get("reasons_unpublished")
             if not reasons_unpublished:

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -3,6 +3,7 @@ import pytest
 from evaluation_registry.evaluations.forms import (
     EvaluationCreateForm,
     EvaluationDesignTypeDetailForm,
+    EvaluationShareForm,
     EventDateForm,
     NullableModelMultipleChoiceField,
 )
@@ -44,3 +45,26 @@ def test_event_date_form(basic_evaluation):
 
     assert form.errors["other_description"] == ["Please provide additional description for the 'Other' choice"]
     assert form.errors["month"] == ["Please enter a month number from 1-12"]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "plan_link, evaluation_link, expected_number_of_errors",
+    [
+        ("test.com", "test.com", 0),
+        ("test.com", "", 0),
+        ("", "test.com", 0),
+        ("", "", 2),
+    ],
+)
+def test_evaluation_share_form(basic_evaluation, plan_link, evaluation_link, expected_number_of_errors):
+    form = EvaluationShareForm(
+        data={
+            "evaluation": basic_evaluation,
+            "is_final_report_published": "1",
+            "plan_link": plan_link,
+            "link_to_published_evaluation": evaluation_link,
+        }
+    )
+
+    assert len(form.errors) == expected_number_of_errors


### PR DESCRIPTION
From ETF feedback, this allows a user to add either a link to a published evaluation or a plan - they don't have to add both.