### PR TITLE
feature/n+1

### DIFF
--- a/evaluation_registry/evaluations/models.py
+++ b/evaluation_registry/evaluations/models.py
@@ -82,7 +82,6 @@ class EvaluationDesignType(AbstractChoice):
         default=False, help_text="Use for 'other' types to prompt further information"
     )
 
-    objects = models.Manager()
     root_objects = RootDesignTypeManager()
 
 

--- a/evaluation_registry/evaluations/models.py
+++ b/evaluation_registry/evaluations/models.py
@@ -52,7 +52,16 @@ class RootDesignTypeManager(models.Manager):
         return super().get_queryset().filter(parent__isnull=True)
 
 
+class AbstractChoiceManager(models.Manager):
+    """this solves the n+1 problem for a recursive model"""
+
+    def get_queryset(self):
+        return super().get_queryset().select_related("parent")
+
+
 class AbstractChoice(TimeStampedModel):
+    objects = AbstractChoiceManager()
+
     code = models.SlugField(
         max_length=128,
         unique=True,

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -43,3 +43,9 @@ def test_rsm_upload(admin_client):
 
     assert response.status_code == 200
     assert Evaluation.objects.count() - initial_count == 3
+
+
+@pytest.mark.django_db
+def test_evaluation_admin_performance(impact_evaluation, admin_client, django_assert_max_num_queries):
+    with django_assert_max_num_queries(20):
+        admin_client.get(f"/admin/evaluations/evaluation/{impact_evaluation.pk}/change/")


### PR DESCRIPTION
previously the `AbstractChoiceModel` was causing an `N+1` problem for recursive queries such as listing all `Taxonomies` whose display name was built out of the parent display.

This PR follows a TDD approach, b5e8cb06f1136cf49798ab1b2a6cae14c123c183  adds a test which expects 20 queries for the evaluation admin but [actually gets 213](https://i-dot-ai.sentry.io/issues/4702839111/?project=4504600165351424&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=0), commit 2d82df83df550fc71492d3af0b4284361b08213d solves this issue.

20 queries is still quite high, we will tackle this in a separate PR.