### PR TITLE
Fix debug-toolbar deployment bug 

### DIFF
--- a/evaluation_registry/settings_base.py
+++ b/evaluation_registry/settings_base.py
@@ -5,12 +5,13 @@ import subprocess
 from pathlib import Path
 
 import environ
-from django.conf import settings
 
 env = environ.Env()
 
 if env.str("ENVIRONMENT", None) != "LOCAL":
     LOCALHOST = socket.gethostbyname(socket.gethostname())
+
+DEBUG = env.bool("DEBUG", default=False)
 
 
 def get_environ_vars() -> dict:
@@ -80,7 +81,7 @@ INSTALLED_APPS = [
     "storages",
 ]
 
-if settings.DEBUG:
+if DEBUG:
     INSTALLED_APPS += ["debug_toolbar"]
 
 
@@ -100,7 +101,7 @@ MIDDLEWARE = [
     "simple_history.middleware.HistoryRequestMiddleware",
 ]
 
-if settings.DEBUG:
+if DEBUG:
     MIDDLEWARE += ["debug_toolbar.middleware.DebugToolbarMiddleware"]
 
 

--- a/evaluation_registry/urls.py
+++ b/evaluation_registry/urls.py
@@ -44,9 +44,9 @@ other_urlpatterns = [
     path("accounts/", include("allauth.urls")),
 ]
 
-development_urlpatterns = [path("__debug__/", include("debug_toolbar.urls"))]
 
 urlpatterns = info_urlpatterns + share_urlpatterns + other_urlpatterns + cola_url_patterns
 
 if settings.DEBUG:
+    development_urlpatterns = [path("__debug__/", include("debug_toolbar.urls"))]
     urlpatterns += development_urlpatterns


### PR DESCRIPTION
## Context

Our production deployments were failing with this error: `ModuleNotFoundError: No module named 'debug_toolbar'`. There had been a fix to a similar problem in #106, where the django debug toolbar (DDT) was listed as a dependency only in a dev environment. However, the line `development_urlpatterns = [path("__debug__/", include("debug_toolbar.urls"))]` was not escaped in a non-debug setting, which caused the error.

## Changes proposed in this pull request
This fixes the error mentioned above.

It also updates how the DEBUG env variable is read in `settings.py`, as previously the DDT was not working locally.

## Guidance to review
Try removing debug_toolbar and settings the DEBUG mode to False locally and see if building the docker container fails.

## Things to check

~- [ ] I have added any new ENV vars in all deployed environments~
