### PR TITLE
Consolidate checks for localhost in settings_base

### DIFF
--- a/evaluation_registry/settings_base.py
+++ b/evaluation_registry/settings_base.py
@@ -10,9 +10,6 @@ from .hosting_environment import HostingEnvironment
 
 env = environ.Env()
 
-if HostingEnvironment.is_local():
-    LOCALHOST = socket.gethostbyname(socket.gethostname())
-
 DEBUG = env.bool("DEBUG", default=False)
 
 
@@ -41,8 +38,6 @@ SECRET_KEY = env.str("DJANGO_SECRET_KEY")
 
 # Add AWS URLS to ALLOWED_HOSTS once known
 ALLOWED_HOSTS = [
-    "localhost",
-    "127.0.0.1",
     "evaluationregistry-dev.eba-iummijp7.eu-west-2.elasticbeanstalk.com",
     "evaluationregistry-prod.eba-iummijp7.eu-west-2.elasticbeanstalk.com",
     "evaluation-registry.cabinetoffice.gov.uk",
@@ -53,7 +48,8 @@ ALLOWED_HOSTS = [
 ]
 
 if HostingEnvironment.is_local():
-    ALLOWED_HOSTS = ALLOWED_HOSTS + [LOCALHOST]
+    localhost = socket.gethostbyname(socket.gethostname())
+    ALLOWED_HOSTS += [localhost, "localhost", "127.0.0.1"]
 
 # CSRF settings
 CSRF_COOKIE_HTTPONLY = True


### PR DESCRIPTION
## Context

I came across this while reviewing #108 — I noticed that the checks were split and the LOCALHOST constant wasn't used anywhere else

## Changes proposed in this pull request

If and only if we're in an local env, add various local hostnames to the ALLOWED_HOSTS list.

## Guidance to review

Does this break anything? (particularly deployment, though it really shouldn't!)

## Things to check

- [X] I have added any new ENV vars in all deployed environments
