### PR TITLE
feature/check to see if app is deployed to beanstalk before loading beanstalk envvars

### DIFF
--- a/evaluation_registry/hosting_environment.py
+++ b/evaluation_registry/hosting_environment.py
@@ -1,9 +1,32 @@
+import ast
+import os
+import subprocess
+
 import environ
 
 env = environ.Env()
 
 
 class HostingEnvironment:
-    @classmethod
-    def is_local(_cls):
+    @staticmethod
+    def is_local() -> bool:
         return env.str("ENVIRONMENT", None) == "LOCAL"
+
+    @staticmethod
+    def is_beanstalk() -> bool:
+        """is this application deployed to AWS Elastic Beanstalk?"""
+        return os.path.exists("/opt/elasticbeanstalk")
+
+    @staticmethod
+    def get_beanstalk_environ_vars() -> dict:
+        """get env vars from ec2
+        https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/custom-platforms-scripts.html
+        """
+        completed_process = subprocess.run(
+            ["/opt/elasticbeanstalk/bin/get-config", "environment"],
+            stdout=subprocess.PIPE,
+            text=True,
+            check=True,
+        )
+
+        return ast.literal_eval(completed_process.stdout)

--- a/evaluation_registry/settings.py
+++ b/evaluation_registry/settings.py
@@ -1,6 +1,4 @@
 # flake8: noqa
-import socket
-
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
 
@@ -122,5 +120,8 @@ OPENAI_KEY = env.str("OPENAI_KEY", default=None)
 # Django debug toolbar
 # https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#configure-internal-ips
 if DEBUG:
-    hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
-    INTERNAL_IPS = [ip[: ip.rfind(".")] + ".1" for ip in ips] + ["127.0.0.1", "10.0.2.2"]
+    try:
+        _hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
+        INTERNAL_IPS = ["127.0.0.1", "10.0.2.2"] + [ip[: ip.rfind(".")] + ".1" for ip in ips]
+    except socket.gaierror:
+        INTERNAL_IPS = ["127.0.0.1", "10.0.2.2"]


### PR DESCRIPTION
## Context

The EBS healthcheck requires us to dynamically workout the `LOCALHOST`, previously we have been calling `is_local` as a proxy to establish whether the application is deployed to EBS or not, now we are using a new method `is_beanstalk` which is more explicit, and hopefully, more reliable.

## Changes proposed in this pull request

1. a new method `HostingEnvironment.is_beanstalk` added
2. `get_environ_vars` is another EBS specific command, it has been moved and renamed as `HostingEnvironment.get_beanstalk_environ_vars`

## Guidance to review

* does this work locally?
* can it be deployed to dev (this is safe to do as there are no migrations)?

## Link to JIRA ticket

https://technologyprogramme.atlassian.net/jira/software/projects/IDOTAI/boards/375?selectedIssue=IDOTAI-54

## Things to check

~- [ ] I have added any new ENV vars in all deployed environments~
