### PR TITLE
Feature/extend health-check

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,4 +53,3 @@ jobs:
         region: eu-west-2
         deployment_package: app.zip
         use_existing_version_if_available: true
-        wait_for_deployment: false

--- a/evaluation_registry/settings.py
+++ b/evaluation_registry/settings.py
@@ -110,6 +110,7 @@ if env.str("AWS_STORAGE_BUCKET_NAME", default=None):
     DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
     AWS_STORAGE_BUCKET_NAME = env.str("AWS_STORAGE_BUCKET_NAME")
     AWS_S3_REGION_NAME = env.str("AWS_REGION_NAME")
+    INSTALLED_APPS += ["health_check.contrib.s3boto3_storage"]
 else:
     DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
 

--- a/evaluation_registry/settings_base.py
+++ b/evaluation_registry/settings_base.py
@@ -48,6 +48,10 @@ WSGI_APPLICATION = "evaluation_registry.wsgi.application"
 
 INSTALLED_APPS = [
     "health_check",
+    "health_check.db",
+    "health_check.contrib.migrations",
+    "health_check.cache",
+    "health_check.storage",
     "evaluation_registry.evaluations",
     "automatilib.core.apps.IdotAIConfig",
     "automatilib.cola.apps.ColaAuthConfig",


### PR DESCRIPTION
## Context

We have had instances in the past where code has been deployed unsuccessfully, the health checks failed, but no one realised because they arent actively monitored. 

## Changes proposed in this pull request

* the health checks are extended to cover all easy wins (those already covered in [django-health-check](https://github.com/revsys/django-health-check))
* merge to main will fail if the deployment to dev is unsuccessful 

## Guidance to review

1. check http://localhost:8000/health/ on current develop, you should see the bare bones health status
<img width="410" alt="image" src="https://github.com/i-dot-ai/evaluation-registry/assets/8233643/a47173dc-552e-41b8-95fe-ba01bb60c2a4">


2. now checkout this branch and you will see the additional checks
<img width="434" alt="image" src="https://github.com/i-dot-ai/evaluation-registry/assets/8233643/605b3875-a7d7-4020-9d2b-c6366a544353">

3. deploy this branch to dev and you will see that the deployment action waits for the application to become healthy 

<img width="951" alt="image" src="https://github.com/i-dot-ai/evaluation-registry/assets/8233643/90d2afb6-9343-4ed6-8064-a238f7d07807">

4. now look at https://dev.evaluation-registry.cabinetoffice.gov.uk/health/ and you will see the s3 status added to the healthchecks
<img width="438" alt="image" src="https://github.com/i-dot-ai/evaluation-registry/assets/8233643/4f004ca7-f3a6-40e7-b929-2de7d6c51b7b">


## Link to JIRA ticket

https://technologyprogramme.atlassian.net/browse/ER-111

## Things to check

~- [ ] I have added any new ENV vars in all deployed environments~
